### PR TITLE
mac80211: fix mt7620 vco calibration registers

### DIFF
--- a/package/kernel/mac80211/patches/020-19-rt2x00-add-support-for-MT7620.patch
+++ b/package/kernel/mac80211/patches/020-19-rt2x00-add-support-for-MT7620.patch
@@ -1022,7 +1022,7 @@ index 8d00c599e47a..201b12ed90c6 100644
  	rt2800_register_write(rt2x00dev, TX_PIN_CFG, tx_pin);
  
 +	if (rt2x00_rt(rt2x00dev, RT6352)) {
-+		if (rt2x00dev->default_ant.tx_chain_num == 1) {
++		if (rt2x00dev->default_ant.rx_chain_num == 1) {
 +			rt2800_bbp_write(rt2x00dev, 91, 0x07);
 +			rt2800_bbp_write(rt2x00dev, 95, 0x1A);
 +			rt2800_bbp_write(rt2x00dev, 195, 128);
@@ -1043,8 +1043,8 @@ index 8d00c599e47a..201b12ed90c6 100644
 +		}
 +
 +		if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
-+			rt2800_bbp_write(rt2x00dev, 75, 0x60);
-+			rt2800_bbp_write(rt2x00dev, 76, 0x44);
++			rt2800_bbp_write(rt2x00dev, 75, 0x68);
++			rt2800_bbp_write(rt2x00dev, 76, 0x4C);
 +			rt2800_bbp_write(rt2x00dev, 79, 0x1C);
 +			rt2800_bbp_write(rt2x00dev, 80, 0x0C);
 +			rt2800_bbp_write(rt2x00dev, 82, 0xB6);


### PR DESCRIPTION
Use register values from init LNA function instead of the ones from restore LNA function. Apply register values based on rx path configuration.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>